### PR TITLE
Update .dockerignore

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,2 +1,1 @@
 Dockerfile
-node_modules


### PR DESCRIPTION
It was ignoring `node_modules` causing a crash on start as the folder wasn't getting copied.