### PR TITLE
Revise incorrect Repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Banking-On-Redis
 
-Banking-On-Redis is a Node.js port of the Java application [Redisbank](https://github.com/Redislabs-Solution-Architects/**redisbank**). 
+Banking-On-Redis is a Node.js port of the Java application [Redisbank](https://github.com/Redislabs-Solution-Architects/redisbank). 
 
 This repository uses Redis core data structures, Streams, JSON, Search and TimeSeries to build a Node.js Express Redis Reactive application that shows a searchable transaction overview with realtime updates as well as a personal finance management overview with realtime balance and biggest spenders updates. UI in Bootstrap/CSS/Vue.
 


### PR DESCRIPTION
There is a wrong Redisbank's repository URL that shown 404 Page on README.
I think people don't know what to do when faced it. So please revise it :)